### PR TITLE
Updated formatting for Finland

### DIFF
--- a/country_telephone_data.js
+++ b/country_telephone_data.js
@@ -477,7 +477,7 @@ var allCountries = [
           'Finland (Suomi)',
           'fi',
           '358',
-          '+... .. ... .. ..'
+          '+... .. .... ....'
        ],
        [
           'France',


### PR DESCRIPTION
Updated the phone number format to correspond to Finnish standard, according to Institute for the languages of Finland. Unfortunately there is no singular way to format phone numbers that would fit both mobile and landlines, but mobile lines are far more common hence I opted for that.
Reference (in finnish): http://www.kielitoimistonohjepankki.fi/haku/puhelinnumerot/ohje/33