### PR TITLE
fix philippines since it has different phone number format length

### DIFF
--- a/country_telephone_data.js
+++ b/country_telephone_data.js
@@ -1104,7 +1104,7 @@ var allCountries = [
           'Philippines',
           'ph',
           '63',
-          '+.. ... ....'
+          '+.. ..........'
        ],
        [
           'Pitcairn Islands',


### PR DESCRIPTION
I do not see any good solution to this, but Philippines phone numbers have different formats, as can be seen here: https://www.howtocallabroad.com/philippines/

So i think it would be better to change the format attribute in the object for 'ph' to allow more digit and only have a space between the country code and the phone number.